### PR TITLE
chore: bump open-webui image to v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.2] - 2025-04-25
+
+### Fixed
+
+- **Update the chatbot to v0.4.2**
+
+
 
 ## [1.0.1] - 2025-04-18
 


### PR DESCRIPTION
1. bump open-webui image to v0.4.2
2. Fix version issue.