### PR TITLE
chore: bump open-webui image to v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2025-05-08
+
+### Fixed
+
+- **Update the chatbot to v0.4.6**
+
+
 ## [1.0.3] - 2025-04-28
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     restart: unless-stopped 
 
   chatbot:
-    image: innodiskorg/open-webui:v0.4.5
+    image: innodiskorg/open-webui:v0.4.6
     container_name: chatbot
     environment:
       - MODEL_HANDLER_IP=model_handler


### PR DESCRIPTION
chatbot update v0.4.7 